### PR TITLE
Fixed issue where tasks looking for unique items would require them multiple times if increasing FIR or CounterCreator conditions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "QCAdjustments",
-    "version": "2.4.0",
+    "version": "2.4.1",
     "sptVersion": "~3.11",
     "loadBefore": [],
     "loadAfter": [

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -129,7 +129,11 @@ class QuestConditionAdjuster implements IPostDBLoadMod {
     multipliers: { [key in ConditionType]?: number },
   ): void {
     const multiplier = multipliers[condition.conditionType];
-    if (typeof condition.value === "number" && multiplier) {
+    if (
+      typeof condition.value === "number" &&
+      multiplier &&
+      condition.value !== 1
+    ) {
       condition.value = Math.ceil(condition.value * multiplier);
     }
   }


### PR DESCRIPTION
Accidentally on a branch :p Not rebasing because public.